### PR TITLE
fix(web): sorted unique view with renaming some visible labels

### DIFF
--- a/srv/fluffi/data/fluffiweb/app/controllers.py
+++ b/srv/fluffi/data/fluffiweb/app/controllers.py
@@ -322,6 +322,11 @@ def getGeneralInformationData(projId, stmt):
         for row in result:
             testcase = type('', (), {})()
             testcase.testcaseID = row["ID"]
+            try:
+                if row["CrashFootprint"] is not None:
+                    testcase.footprint = row["CrashFootprint"]
+            except Exception as e:
+                print(e)
             testcase.id = "{}:{}".format(row["CreatorServiceDescriptorGUID"], row["CreatorLocalID"])
             testcase.rating = row["Rating"]
             testcase.niceName = row["NiceName"]

--- a/srv/fluffi/data/fluffiweb/app/queries.py
+++ b/srv/fluffi/data/fluffiweb/app/queries.py
@@ -101,15 +101,17 @@ UNIQUE_ACCESS_VIOLATION = (
     "LEFT JOIN nice_names_testcase AS nn ON av.ID = nn.TestcaseID;")
 
 UNIQUE_ACCESS_VIOLATION_NO_RAW = (
-    "SELECT av.ID, av.TestCaseType, av.CreatorServiceDescriptorGUID, av.CreatorLocalID, av.Rating, "
-    "av.TimeOfInsertion, nn.NiceName "
-    "FROM "
-    "(SELECT cd.CrashFootprint, it.TestCaseType, it.CreatorServiceDescriptorGUID, it.CreatorLocalID, it.Rating, "
-    "it.TimeOfInsertion, it.ID, it.RawBytes"
-    " FROM interesting_testcases AS it"
-    " JOIN crash_descriptions AS cd ON it.ID = cd.CreatorTestcaseID "
-    " WHERE it.TestCaseType=2 Group by cd.CrashFootprint) av "     
-    "LEFT JOIN nice_names_testcase AS nn ON av.ID = nn.TestcaseID;")
+    "SELECT av.ID, av.CrashFootprint, av.TestCaseType, av.CreatorServiceDescriptorGUID, av.CreatorLocalID, av.Rating, "
+	"av.TimeOfInsertion, nn.NiceName "
+    "FROM (SELECT cd.CrashFootprint, it.TestCaseType, it.CreatorServiceDescriptorGUID, it.CreatorLocalID, "
+	"MIN(it.TimeOfInsertion) as TimeOfInsertion, it.ID, count(cd.CrashFootprint) as Rating "
+	"FROM interesting_testcases AS it "
+	"JOIN crash_descriptions AS cd ON it.ID = cd.CreatorTestcaseID "
+	"WHERE it.TestCaseType=2 "
+	"Group by cd.CrashFootprint) as av "
+    "LEFT JOIN nice_names_testcase AS nn "
+    "ON av.ID = nn.TestcaseID "
+    "ORDER BY av.TimeOfInsertion asc;")
 
 NUM_UNIQUE_CRASH = (
     "SELECT count(*) "
@@ -132,17 +134,18 @@ UNIQUE_CRASHES = (
     "WHERE TestCaseType=3;")
 
 UNIQUE_CRASHES_NO_RAW = (
-    "SELECT oc.ID, oc.TestCaseType, oc.CreatorServiceDescriptorGUID, "
-    "oc.CreatorLocalID, oc.Rating, oc.TimeOfInsertion, nn.NiceName "
-    "FROM "
-    "(SELECT cd.CrashFootprint, it.TestCaseType, it.CreatorServiceDescriptorGUID, it.CreatorLocalID, "
-    "it.Rating, it.TimeOfInsertion, it.ID, it.RawBytes"
-    " FROM interesting_testcases AS it"
-    " JOIN crash_descriptions AS cd"
-    " ON it.ID = cd.CreatorTestcaseID "
-    " GROUP BY cd.CrashFootprint) oc " 
-    "LEFT JOIN nice_names_testcase AS nn ON oc.ID = nn.TestcaseID "
-    "WHERE TestCaseType=3;")
+    "SELECT oc.ID, oc.CrashFootprint, oc.TestCaseType, oc.CreatorServiceDescriptorGUID, oc.CreatorLocalID, oc.Rating, "
+    "oc.TimeOfInsertion, nn.NiceName "
+    "FROM (SELECT cd.CrashFootprint, it.TestCaseType, it.CreatorServiceDescriptorGUID, it.CreatorLocalID, "
+    "MIN(it.TimeOfInsertion) as TimeOfInsertion, it.ID, count(cd.CrashFootprint) as Rating "
+    "FROM interesting_testcases AS it "
+    "JOIN crash_descriptions AS cd "
+    "ON it.ID = cd.CreatorTestcaseID "
+    "WHERE TestCaseType=3 "
+    "GROUP BY cd.CrashFootprint) as oc "
+    "LEFT JOIN nice_names_testcase AS nn "
+    "ON oc.ID = nn.TestcaseID "
+    "ORDER BY oc.TimeOfInsertion asc;")
 
 MANAGED_INSTANCES_HOST_AND_PORT_AGENT_TYPE = (
     "SELECT managed_instances.ServiceDescriptorHostAndPort "

--- a/srv/fluffi/data/fluffiweb/app/static/css/fluffi.css
+++ b/srv/fluffi/data/fluffiweb/app/static/css/fluffi.css
@@ -350,3 +350,18 @@ Author(s): Junes Najah, Pascal Eckmann, Michael Kraus, Thomas Riedmaier
     background-color: #286090;
     cursor: pointer;
 }
+
+.tc_view_center {
+    text-align: center;
+}
+
+.tc_view_center_child {
+    display: inline-block;
+}
+
+#addTestcase {
+    width: 100%;
+    background: #eee;
+    padding: 5px;
+    border-radius: 5px;
+}

--- a/srv/fluffi/data/fluffiweb/app/templates/viewAccessViolations.html
+++ b/srv/fluffi/data/fluffiweb/app/templates/viewAccessViolations.html
@@ -25,11 +25,11 @@ Author(s): Junes Najah, Michael Kraus, Thomas Riedmaier
 </div>
 
 <div class="container">
-    <h2>Testcases</h2>
+    <h2></h2>
     <table class="table">
         <thead>
         <tr>
-            <th style="text-align: center;">Count</th>
+            <th style="text-align: center;">Occurences</th>
             <th style="text-align: center;">CrashFootprint</th>
             <th style="text-align: center;">Type</th>
             <th style="text-align: center;">Download</th>

--- a/srv/fluffi/data/fluffiweb/app/templates/viewTCsTempl.html
+++ b/srv/fluffi/data/fluffiweb/app/templates/viewTCsTempl.html
@@ -84,21 +84,20 @@ function addPages(actualPage, pageCount){
 <hr>
 
 <div class="container">
-    <h2 style="margin-bottom: 30px">Testcases</h2>
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-6 tc_view_center">
             {% if data.name == "Population" %}
             <form action="{{ url_for('addTestcase', projId=data.project.id) }}" enctype="multipart/form-data"
                   method="POST">
                 <div class="form-group">
                     <input class="form-control-file" id="addTestcase" multiple name="addTestcase" type="file">
-                    <input class="btn btn-default" style="margin-top: 10px" type="submit" value="Add Testcase(s)"/>
+                    <input class="btn btn-default" style="margin-top: 10px; float: right;" type="submit" value="Add Testcase(s)"/>
                 </div>
             </form>
             {% endif %}
         </div>
-        <div class="col-md-6">
-            <a class="btn btn-primary" href="{{ url_for(data.downloadName, projId=data.project.id) }}" role="button">Download {{ data.name }}</a>
+        <div class="col-md-6 tc_view_center">
+            <a class="btn btn-primary tc_view_center_child" href="{{ url_for(data.downloadName, projId=data.project.id) }}" role="button">Download {{ data.name }}</a>
         </div>
     </div>
     <hr>
@@ -109,13 +108,20 @@ function addPages(actualPage, pageCount){
         <thead>
         <tr>
             <th>
+                {% if show_occurences %}
+                CrashFootprint
+                {% else %}
                 <div data-placement="left" data-toggle="tooltip"
                      title="To add or update a nice name just click on it, type and press enter">
                     ID / Nice Name
                 </div>
+                {% endif %}
             </th>
             {% if show_rating %}
             <th>Rating</th>
+            {% endif %}
+            {% if show_occurences %}
+            <th>Occurences</th>
             {% endif %}
             <th>Time Of Insertion</th>
             <th>Operations</th>
@@ -124,23 +130,27 @@ function addPages(actualPage, pageCount){
         <tbody>
         {% for testcase in data.testcases %}
         <tr>
-            <td>{% if testcase.niceName %}
-                <button id="tcBtn{{loop.index}}"
-                        onclick="addOrRenameNiceName({{ loop.index }}, {{ data.project.id }}, 'update', '{{ testcase.testcaseID }}', '')"
-                        class="btn-desgin">
-                    {{ testcase.niceName }}
-                </button>
-                <input class="form-control" id="tcInput{{loop.index}}" style="display: none;" type="text">
+            <td>{% if testcase.footprint %}
+                {{ testcase.footprint }}
                 {% else %}
-                <button id="tcBtnNew{{loop.index}}"
-                        onclick="addOrRenameNiceName({{ loop.index }}, {{ data.project.id }}, 'insert', '{{ testcase.testcaseID }}', '')"
-                        class="btn-desgin">
-                    {{ testcase.id }}
-                </button>
-                <input class="form-control" id="tcInputNew{{loop.index}}" style="display: none;" type="text">
+                    {% if testcase.niceName %}
+                    <button id="tcBtn{{loop.index}}"
+                            onclick="addOrRenameNiceName({{ loop.index }}, {{ data.project.id }}, 'update', '{{ testcase.testcaseID }}', '')"
+                            class="btn-desgin">
+                        {{ testcase.niceName }}
+                    </button>
+                    <input class="form-control" id="tcInput{{loop.index}}" style="display: none;" type="text">
+                    {% else %}
+                    <button id="tcBtnNew{{loop.index}}"
+                            onclick="addOrRenameNiceName({{ loop.index }}, {{ data.project.id }}, 'insert', '{{ testcase.testcaseID }}', '')"
+                            class="btn-desgin">
+                        {{ testcase.id }}
+                    </button>
+                    <input class="form-control" id="tcInputNew{{loop.index}}" style="display: none;" type="text">
+                    {% endif %}
                 {% endif %}
             </td>
-            {% if show_rating %}
+            {% if show_rating or show_occurences %}
             <td>{{ testcase.rating }}</td>
             {% endif %}
             <td>{{ testcase.timeOfInsertion | default('', True) }}</td>

--- a/srv/fluffi/data/fluffiweb/app/views.py
+++ b/srv/fluffi/data/fluffiweb/app/views.py
@@ -433,7 +433,8 @@ def viewAccessVioUnique(projId):
 
     return renderTemplate("viewTCsTempl.html",
                           title="View Unique Access Violations",
-                          data=data)
+                          data=data,
+                          show_occurences=True)
 
 
 @app.route("/projects/<int:projId>/accessVioUnique/download")
@@ -486,7 +487,8 @@ def viewUniqueCrashes(projId):
 
     return renderTemplate("viewTCsTempl.html",
                           title="View Unique Crashes",
-                          data=data)
+                          data=data,
+                          show_occurences=True)
 
 
 @app.route("/projects/<int:projId>/uniqueCrashes/download")


### PR DESCRIPTION
Crashes in accessVioUnique and uniqueCrashes sorted by time of insertion.

Renamed ID/Nice Name to Footprint.

Time of insertion is the earliest timestamp for each group (aka those crashes that share the same crash footprint).

Furthermore, the Rating column is replaced by a "Occurences" column that counts the members for each group.

+ Additional speed improvements for  accessVioUnique and uniqueCrashes view.