### PR TITLE
fix(dependencies): update commit in build scripts

### DIFF
--- a/core/dependencies/dynamorio/make_dep.bat
+++ b/core/dependencies/dynamorio/make_dep.bat
@@ -42,7 +42,7 @@ REM Getting dynamorio from git
 
 git clone https://github.com/DynamoRIO/dynamorio.git
 cd dynamorio
-git checkout bcc0eee9c171ca44ca5b2f92a6fff8e260852862
+git checkout dadb8ff2eeb173e34d9feaef6f6d8da53666a256
 
 REM Copy files for the drcovMulti module
 MKDIR clients\drcovMulti

--- a/core/dependencies/dynamorio/make_dep.sh
+++ b/core/dependencies/dynamorio/make_dep.sh
@@ -46,7 +46,7 @@ rm -rf dynamorio
 
 git clone https://github.com/DynamoRIO/dynamorio.git
 cd dynamorio
-git checkout bcc0eee9c171ca44ca5b2f92a6fff8e260852862
+git checkout dadb8ff2eeb173e34d9feaef6f6d8da53666a256
 
 # Copy files for the drcovMulti module
 mkdir -p clients/drcovMulti


### PR DESCRIPTION
Updated commit in build scripts, because of #39 and [AVX-512 handling breaks DynamoRIO execution on Windows with full AVX-512 support](https://github.com/DynamoRIO/dynamorio/issues/3949).