### PR TITLE
added support for vs2017

### DIFF
--- a/core/FluffiTester/FluffiTester.vcxproj
+++ b/core/FluffiTester/FluffiTester.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -184,7 +184,7 @@ Author(s): Abian Blome, Thomas Riedmaier, Michael Kraus, Fabian Russwurm
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|x64'">
@@ -202,7 +202,7 @@ Author(s): Abian Blome, Thomas Riedmaier, Michael Kraus, Fabian Russwurm
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;libmariadbd.lib;SharedCoded.lib;SharedMemIPC.lib;GlobalManager.lib;LocalManager.lib;TestcaseGenerator.lib;TestcaseRunner.lib;TestcaseEvaluator.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;libmariadbd.lib;SharedCoded.lib;SharedMemIPC.lib;GlobalManager.lib;LocalManager.lib;TestcaseGenerator.lib;TestcaseRunner.lib;TestcaseEvaluator.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
     <PostBuildEvent>

--- a/core/GlobalManager/GlobalManager.vcxproj
+++ b/core/GlobalManager/GlobalManager.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -155,7 +155,7 @@ Author(s): Thomas Riedmaier, Abian Blome
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x86" "$(TargetDir)." libmariadbd.*
@@ -180,7 +180,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x86" "$(TargetDir)." libmariadbd.*
@@ -205,7 +205,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x64" "$(TargetDir)." libmariadbd.*
@@ -230,7 +230,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x64" "$(TargetDir)." libmariadbd.*
@@ -259,7 +259,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x86" "$(TargetDir)." libmariadb.*
@@ -288,7 +288,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /w:1 /r:1 "$(SolutionDir)dependencies\mariadb\bin\x64" "$(TargetDir)." libmariadb.*

--- a/core/LocalManager/LocalManager.vcxproj
+++ b/core/LocalManager/LocalManager.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -155,7 +155,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">
@@ -171,7 +171,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -187,7 +187,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|x64'">
@@ -203,7 +203,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;libmariadbd.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -223,7 +223,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -243,7 +243,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;libmariadb.lib;Pdh.lib;Rpcrt4.lib;Shlwapi.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/core/TestcaseEvaluator/TestcaseEvaluator.vcxproj
+++ b/core/TestcaseEvaluator/TestcaseEvaluator.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -155,7 +155,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">
@@ -171,7 +171,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -187,7 +187,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|x64'">
@@ -203,7 +203,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -223,7 +223,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -243,7 +243,7 @@ Author(s): Roman Bendt, Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/core/TestcaseGenerator/TestcaseGenerator.vcxproj
+++ b/core/TestcaseGenerator/TestcaseGenerator.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -155,7 +155,7 @@ Author(s): Roman Bendt, Thomas Riedmaier, Abian Blome
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x86" "$(TargetDir)." 
@@ -180,7 +180,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x86" "$(TargetDir)."
@@ -205,7 +205,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzzd.lib;afl-fuzzd.lib;easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x64" "$(TargetDir)."
@@ -230,7 +230,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x64" "$(TargetDir)."
@@ -259,7 +259,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>honggfuzz.lib;afl-fuzz.lib;easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzz.lib;afl-fuzz.lib;easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x86" "$(TargetDir)."
@@ -288,7 +288,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>honggfuzz.lib;afl-fuzz.lib;easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>honggfuzz.lib;afl-fuzz.lib;easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\radamsa\bin\x64" "$(TargetDir)."

--- a/core/TestcaseRunner/TestcaseRunner.vcxproj
+++ b/core/TestcaseRunner/TestcaseRunner.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -155,7 +155,7 @@ Author(s): Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPCd.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPCd.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
     <PostBuildEvent>
@@ -181,7 +181,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\dynamorio\dyndist32" "$(TargetDir)dyndist32" /E
@@ -206,7 +206,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPCd.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPCd.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
     <PostBuildEvent>
@@ -232,7 +232,7 @@ exit 0</Command>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;libprotobufd.lib;libzmq-mt-gd.lib;SharedCoded.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\dynamorio\dyndist64" "$(TargetDir)dyndist64" /E
@@ -261,7 +261,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\dynamorio\dyndist32" "$(TargetDir)dyndist32" /E
@@ -290,7 +290,7 @@ exit 0</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>No</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;libprotobuf.lib;libzmq-mt.lib;SharedCode.lib;Ws2_32.lib;Iphlpapi.lib;Pdh.lib;Rpcrt4.lib;SharedMemIPC.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(SolutionDir)dependencies\dynamorio\dyndist64" "$(TargetDir)dyndist64" /E

--- a/core/build.bat
+++ b/core/build.bat
@@ -8,39 +8,115 @@
 :: 
 :: Author(s): Thomas Riedmaier, Roman Bendt
 
-:: Requires Visual CPP Build Tools 2015 Update 3
 
-:: Fluffi x64
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+IF [%1]==[2017] (
 
-:: Fluffi x86
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	REM Requires Visual STUD 2017 Update 3	
+	cd FluffiTester
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Starter x64
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd GlobalManager
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Starter x86
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd LocalManager
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
+	
+	cd SharedCode
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
+	
+	cd SharedMemIPC
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Feeder x64
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd TestcaseEvaluator
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Feeder x86
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd TestcaseGenerator
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Fuzzcmp x64
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd TestcaseRunner
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
 
-:: Fuzzcmp x86
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-if errorlevel 1 goto errorDone
+	cd Helpers
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace '<PlatformToolset>v140</PlatformToolset>', '<PlatformToolset>v141</PlatformToolset>' } | sc $f.PSPath }"
+	cd ..
+
+	:: Fluffi x64
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Fluffi x86
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Starter x64
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Starter x86
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Feeder x64
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Feeder x86
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+	
+	:: Fuzzcmp x64
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+
+	:: Fuzzcmp x86
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	if errorlevel 1 goto errorDone
+	
+) ELSE (
+
+	REM Requires Visual CPP Build Tools 2015 Update 3
+
+	:: Fluffi x64
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Fluffi x86
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" FluffiV1.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Starter x64
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Starter x86
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Starter\Starter.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Feeder x64
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Feeder x86
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\Feeder\Feeder.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+	
+	:: Fuzzcmp x64
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+
+	:: Fuzzcmp x86
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" helpers\fuzzcmp\fuzzcmp.sln /m  /t:Build /p:Configuration=Release /p:Platform=x86 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	if errorlevel 1 goto errorDone
+	
+)
 
 :: Requires at least go 1.12
 

--- a/core/dependencies/afl/make_dep.bat
+++ b/core/dependencies/afl/make_dep.bat
@@ -38,7 +38,14 @@ mkdir build64
 mkdir build86
 SETLOCAL
 cd build64
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+IF [%1]==[2017] (
+	ECHO Build for vs2017 
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+) ELSE (
+	ECHO Build for vs2015
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+)
 
 cl.exe /MT /c /TP /EHsc ..\afl-fuzz.c
 LIB.EXE /OUT:afl-fuzz.LIB afl-fuzz.obj
@@ -49,7 +56,12 @@ ENDLOCAL
 
 SETLOCAL
 cd build86
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+
+IF [%1]==[2017] (
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+) ELSE (
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+)
 
 cl.exe /MT /c /TP /EHsc ..\afl-fuzz.c
 LIB.EXE /OUT:afl-fuzz.LIB afl-fuzz.obj

--- a/core/dependencies/base64/make_dep.bat
+++ b/core/dependencies/base64/make_dep.bat
@@ -43,7 +43,14 @@ mkdir build64
 mkdir build86
 SETLOCAL
 cd build64
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+IF [%1]==[2017] (
+	ECHO Build for vs2017
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+) ELSE (
+	ECHO Build for vs2015
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+)
 
 cl.exe /MT /c /EHsc ..\base64.cpp
 LIB.EXE /OUT:base64.LIB base64.obj
@@ -54,7 +61,14 @@ ENDLOCAL
 
 SETLOCAL
 cd build86
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+
+IF [%1]==[2017] (
+	ECHO Build for vs2017
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+) ELSE (
+	ECHO Build for vs2017
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+)
 
 cl.exe /MT /c /EHsc ..\base64.cpp
 LIB.EXE /OUT:base64.LIB base64.obj

--- a/core/dependencies/dynamorio/make_dep.bat
+++ b/core/dependencies/dynamorio/make_dep.bat
@@ -59,23 +59,41 @@ REM Building dynamorio
 mkdir build64
 mkdir build86
 cd build64
-SETLOCAL
-set PATH=C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin;%PATH%
-call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
-cmake -G "Visual Studio 12 2013 Win64" -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v120"
-ENDLOCAL
-cd ..
-cd build86
-SETLOCAL
-call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
-cmake -G "Visual Studio 12 2013"  -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v120"
-ENDLOCAL
+IF [%1]==[2017] (
+	SETLOCAL
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+	cmake -G "Visual Studio 15 2017 Win64" -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	cd ..
+	cd build86
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+	cmake -G "Visual Studio 15 2017"  -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	ENDLOCAL
+) ELSE (
+	SETLOCAL
+	call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+	cmake -G "Visual Studio 12 2013 Win64" -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v120"
+	ENDLOCAL
+	cd ..
+	cd build86
+	SETLOCAL
+	call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+	cmake -G "Visual Studio 12 2013"  -DBUILD_CORE=ON -DBUILD_DOCS=OFF -DBUILD_DRSTATS=OFF -DBUILD_TOOLS=ON -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DDEBUG=OFF -DCMAKE_WARN_DEPRECATED=OFF  ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe" DynamoRIO.sln /m /t:Build /p:Configuration=RelWithDebInfo /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v120"
+	ENDLOCAL
+)
+
+
 cd ..
 cd ..
 

--- a/core/dependencies/easylogging/make_dep.bat
+++ b/core/dependencies/easylogging/make_dep.bat
@@ -35,22 +35,42 @@ REM Building easylogging lib
 mkdir build64
 mkdir build86
 cd build64
-cmake -G "Visual Studio 14 2015 Win64" -Dbuild_static_lib=ON ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-cd ..
-cd build86
-cmake -G "Visual Studio 14 2015" -Dbuild_static_lib=ON ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+IF [%1]==[2017] (
+	cmake -G "Visual Studio 15 2017 Win64" -Dbuild_static_lib=ON ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 15 2017" -Dbuild_static_lib=ON ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+) ELSE (
+	cmake -G "Visual Studio 14 2015 Win64" -Dbuild_static_lib=ON ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 14 2015" -Dbuild_static_lib=ON ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp</TargetName>', 'easyloggingppd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'easyloggingpp.lib', 'easyloggingppd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Easyloggingpp.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+)
+
 cd ..
 cd ..
 

--- a/core/dependencies/honggfuzz/make_dep.bat
+++ b/core/dependencies/honggfuzz/make_dep.bat
@@ -39,27 +39,53 @@ REM Building honggfuzz
 
 mkdir build64
 mkdir build86
-SETLOCAL
-cd build64
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 
-cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
-LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
-cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
-LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
-cd ..
-ENDLOCAL
+IF [%1]==[2017] (
+	SETLOCAL
+	cd build64
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 
-SETLOCAL
-cd build86
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+	cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
+	cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
+	cd ..
+	ENDLOCAL
 
-cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
-LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
-cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
-LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
-cd ..
-ENDLOCAL
+	SETLOCAL
+	cd build86
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+
+	cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
+	cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
+	cd ..
+	ENDLOCAL
+) ELSE (
+	SETLOCAL
+	cd build64
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+	cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
+	cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
+	cd ..
+	ENDLOCAL
+
+	SETLOCAL
+	cd build86
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+
+	cl.exe /MT /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzz.LIB mangle.obj util.obj input.obj
+	cl.exe /MTd /Debug /c /TP /EHsc ..\mangle.c ..\libhfcommon\util.c ..\input.c
+	LIB.EXE /OUT:honggfuzzd.LIB mangle.obj util.obj input.obj
+	cd ..
+	ENDLOCAL
+)
+
 cd ..
 
 

--- a/core/dependencies/libprotoc/make_dep.bat
+++ b/core/dependencies/libprotoc/make_dep.bat
@@ -53,19 +53,36 @@ cd protobuf
 git checkout 106ffc04be1abf3ff3399f54ccf149815b287dd9
 mkdir build64
 mkdir build86
-cd build64
-cmake -G "Visual Studio 14 2015 Win64" -Dprotobuf_BUILD_TESTS=OFF ../cmake
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-cd ..
-cd build86
-cmake -G "Visual Studio 14 2015" -Dprotobuf_BUILD_TESTS=OFF ../cmake
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+
+IF [%1]==[2017] (
+	cd build64
+	cmake -G "Visual Studio 15 2017 Win64" -Dprotobuf_BUILD_TESTS=OFF ../cmake
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 15 2017" -Dprotobuf_BUILD_TESTS=OFF ../cmake
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+) ELSE (
+	cd build64
+	cmake -G "Visual Studio 14 2015 Win64" -Dprotobuf_BUILD_TESTS=OFF ../cmake
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 14 2015" -Dprotobuf_BUILD_TESTS=OFF ../cmake
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" protobuf.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+)
 cd ..
 cd ..
 

--- a/core/dependencies/make_all_dep.bat
+++ b/core/dependencies/make_all_dep.bat
@@ -16,51 +16,51 @@
 :: - Network access to github and gitlab
 
 cd zeromq
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd libprotoc
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd dynamorio
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd mariadb
-call make_dep.bat
-IF errorlevel 1 goto :err
-cd ..
-
-cd radamsa
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd easylogging
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd openssl
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd base64
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd afl
-call make_dep.bat
+call make_dep.bat %1
 IF errorlevel 1 goto :err
 cd ..
 
 cd honggfuzz
+call make_dep.bat %1
+IF errorlevel 1 goto :err
+cd ..
+
+cd radamsa
 call make_dep.bat
 IF errorlevel 1 goto :err
 cd ..

--- a/core/dependencies/mariadb/make_dep.bat
+++ b/core/dependencies/mariadb/make_dep.bat
@@ -39,24 +39,47 @@ git checkout bce6c8013805f203b38e52c979b22b3141334f3c
 mkdir build64
 mkdir build86
 cd build64
-cmake -G "Visual Studio 14 2015 Win64" ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-cd ..
-cd build86
-cmake -G "Visual Studio 14 2015" ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+IF [%1]==[2017] (
+	cmake -G "Visual Studio 15 2017 Win64" ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 15 2017" ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+
+) ELSE (
+	cmake -G "Visual Studio 14 2015 Win64" ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 14 2015" ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb</TargetName>', 'libmariadbd</TargetName>' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.pdb', 'libmariadbd.pdb' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libmariadb.lib', 'libmariadbd.lib' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" mariadb-connector-c.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+)
+
 cd ..
 cd ..
 

--- a/core/dependencies/openssl/make_dep.bat
+++ b/core/dependencies/openssl/make_dep.bat
@@ -39,34 +39,66 @@ mkdir build64
 mkdir build86
 mkdir build64d
 mkdir build86d
-SETLOCAL
-cd build64
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-set CL=/MP
-set __CNF_LDLIBS=-static
-perl ..\Configure VC-WIN64A --release no-tests no-unit-test no-asm enable-static-engine no-shared
-"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\nmake.exe"
-cd ..
-cd build64d
-perl ..\Configure VC-WIN64A --debug no-tests no-unit-test no-asm enable-static-engine no-shared
-"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\nmake.exe"
-cd ..
-ENDLOCAL
+IF [%1]==[2017] (
+	SETLOCAL
+	cd build64
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+	set CL=/MP
+	set __CNF_LDLIBS=-static
+	perl ..\Configure VC-WIN64A --release no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\nmake.exe"
+	cd ..
+	cd build64d
+	perl ..\Configure VC-WIN64A --debug no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\nmake.exe"
+	cd ..
+	ENDLOCAL
 
 
-SETLOCAL
-cd build86
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-set CL=/MP
-set __CNF_LDLIBS=-static
-perl ..\Configure VC-WIN32 --release no-tests no-unit-test no-asm enable-static-engine no-shared
-"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\nmake.exe"
-cd ..
-cd build86d
-perl ..\Configure VC-WIN32 --debug no-tests no-unit-test no-asm enable-static-engine no-shared
-"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\nmake.exe"
-cd ..
-ENDLOCAL
+	SETLOCAL
+	cd build86
+	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+	set CL=/MP
+	set __CNF_LDLIBS=-static
+	perl ..\Configure VC-WIN32 --release no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx86\x86\nmake.exe"
+	cd ..
+	cd build86d
+	perl ..\Configure VC-WIN32 --debug no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx86\x86\nmake.exe"
+	cd ..
+	ENDLOCAL
+) ELSE (
+	SETLOCAL
+	cd build64
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+	set CL=/MP
+	set __CNF_LDLIBS=-static
+	perl ..\Configure VC-WIN64A --release no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\nmake.exe"
+	cd ..
+	cd build64d
+	perl ..\Configure VC-WIN64A --debug no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\nmake.exe"
+	cd ..
+	ENDLOCAL
+
+
+	SETLOCAL
+	cd build86
+	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+	set CL=/MP
+	set __CNF_LDLIBS=-static
+	perl ..\Configure VC-WIN32 --release no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\nmake.exe"
+	cd ..
+	cd build86d
+	perl ..\Configure VC-WIN32 --debug no-tests no-unit-test no-asm enable-static-engine no-shared
+	"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\nmake.exe"
+	cd ..
+	ENDLOCAL
+)
+
 cd ..
 
 

--- a/core/dependencies/zeromq/make_dep.bat
+++ b/core/dependencies/zeromq/make_dep.bat
@@ -37,38 +37,69 @@ git checkout 2cb1240db64ce1ea299e00474c646a2453a8435b
 mkdir build64
 mkdir build86
 cd build64
-cmake -G "Visual Studio 14 2015 Win64" -DBUILD_TESTS=OFF ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+
+IF [%1]==[2017] (
+	ECHO Build for vs2017
+	cmake -G "Visual Studio 15 2017 Win64" -DBUILD_TESTS=OFF ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v141-mt-gd-4_3_1', 'libzmq-mt-gd' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v141-mt-4_3_1', 'libzmq-mt' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 15 2017" -DBUILD_TESTS=OFF ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v141-mt-gd-4_3_1', 'libzmq-mt-gd' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v141-mt-4_3_1', 'libzmq-mt' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets"
+	
+ ) ELSE (
+	ECHO Build for vs2015
+	cmake -G "Visual Studio 14 2015 Win64" -DBUILD_TESTS=OFF ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v140-mt-gd-4_3_1', 'libzmq-mt-gd' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v140-mt-4_3_1', 'libzmq-mt' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=x64 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	
+	cd ..
+	cd build86
+	cmake -G "Visual Studio 14 2015" -DBUILD_TESTS=OFF ..
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v140-mt-gd-4_3_1', 'libzmq-mt-gd' } | sc $f.PSPath }"
+	powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'libzmq-v140-mt-4_3_1', 'libzmq-mt' } | sc $f.PSPath }"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+	
+)
+
 cd ..
-cd build86
-cmake -G "Visual Studio 14 2015" -DBUILD_TESTS=OFF ..
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDebugDll', 'MultiThreadedDebug' } | sc $f.PSPath }"
-powershell -Command "ls *.vcxproj -rec | %%{ $f=$_; (gc $f.PSPath) | %%{ $_ -replace 'MultiThreadedDll', 'MultiThreaded' } | sc $f.PSPath }"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Release /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" ZeroMQ.sln /m /t:Build /p:Configuration=Debug /p:Platform=Win32 /property:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-cd ..
 cd ..
 
-copy libzmq\build64\bin\Release\libzmq-v140-mt-4_3_1.dll bin\x64
-copy libzmq\build64\lib\Release\libzmq-v140-mt-4_3_1.lib lib\x64
-copy libzmq\build64\lib\Release\libzmq-v140-mt-4_3_1.exp lib\x64
+copy libzmq\build64\bin\Release\libzmq-mt.dll bin\x64
+copy libzmq\build64\lib\Release\libzmq-mt.lib lib\x64
+copy libzmq\build64\lib\Release\libzmq-mt.exp lib\x64
 
-copy libzmq\build64\bin\Debug\libzmq-v140-mt-gd-4_3_1.dll bin\x64
-copy libzmq\build64\bin\Debug\libzmq-v140-mt-gd-4_3_1.pdb bin\x64
-copy libzmq\build64\lib\Debug\libzmq-v140-mt-gd-4_3_1.lib lib\x64
-copy libzmq\build64\lib\Debug\libzmq-v140-mt-gd-4_3_1.exp lib\x64
+copy libzmq\build64\bin\Debug\libzmq-mt-gd.dll bin\x64
+copy libzmq\build64\bin\Debug\libzmq-mt-gd.pdb bin\x64
+copy libzmq\build64\lib\Debug\libzmq-mt-gd.lib lib\x64
+copy libzmq\build64\lib\Debug\libzmq-mt-gd.exp lib\x64
 
-copy libzmq\build86\bin\Release\libzmq-v140-mt-4_3_1.dll bin\x86
-copy libzmq\build86\lib\Release\libzmq-v140-mt-4_3_1.lib lib\x86
-copy libzmq\build86\lib\Release\libzmq-v140-mt-4_3_1.exp lib\x86
+copy libzmq\build86\bin\Release\libzmq-mt.dll bin\x86
+copy libzmq\build86\lib\Release\libzmq-mt.lib lib\x86
+copy libzmq\build86\lib\Release\libzmq-mt.exp lib\x86
 
-copy libzmq\build86\bin\Debug\libzmq-v140-mt-gd-4_3_1.dll bin\x86
-copy libzmq\build86\bin\Debug\libzmq-v140-mt-gd-4_3_1.pdb bin\x86
-copy libzmq\build86\lib\Debug\libzmq-v140-mt-gd-4_3_1.lib lib\x86
-copy libzmq\build86\lib\Debug\libzmq-v140-mt-gd-4_3_1.exp lib\x86
+copy libzmq\build86\bin\Debug\libzmq-mt-gd.dll bin\x86
+copy libzmq\build86\bin\Debug\libzmq-mt-gd.pdb bin\x86
+copy libzmq\build86\lib\Debug\libzmq-mt-gd.lib lib\x86
+copy libzmq\build86\lib\Debug\libzmq-mt-gd.exp lib\x86
 
 copy libzmq\include\zmq.h include
 

--- a/core/helpers/Feeder/Tester/Tester.vcxproj
+++ b/core/helpers/Feeder/Tester/Tester.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2017-2019 Siemens AG
 
@@ -115,7 +115,7 @@ Author(s): Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;SharedCoded.lib;ws2_32.lib;SharedMemIPCd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;SharedCoded.lib;ws2_32.lib;SharedMemIPCd.lib;libprotobufd.lib;libzmq-mt-gd.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -131,7 +131,7 @@ Author(s): Thomas Riedmaier
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingppd.lib;SharedCoded.lib;ws2_32.lib;SharedMemIPCd.lib;libprotobufd.lib;libzmq-v140-mt-gd-4_3_1.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingppd.lib;SharedCoded.lib;ws2_32.lib;SharedMemIPCd.lib;libprotobufd.lib;libzmq-mt-gd.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -151,7 +151,7 @@ Author(s): Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;SharedCode.lib;ws2_32.lib;SharedMemIPC.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;SharedCode.lib;ws2_32.lib;SharedMemIPC.lib;libprotobuf.lib;libzmq-mt.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -171,7 +171,7 @@ Author(s): Thomas Riedmaier
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>easyloggingpp.lib;SharedCode.lib;ws2_32.lib;SharedMemIPC.lib;libprotobuf.lib;libzmq-v140-mt-4_3_1.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>easyloggingpp.lib;SharedCode.lib;ws2_32.lib;SharedMemIPC.lib;libprotobuf.lib;libzmq-mt.lib;Rpcrt4.lib;Iphlpapi.lib;Pdh.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Uses flag VSVER=2017 when launching buildAll.bat to build for vstudio 2017. If flag not present will build for vs2015.
Change name for libzmq to not include anymore platform and version in lib, dll, pdb, exp files.