### PR TITLE
fix(web): fix layout to avoid overlapping of node labels

### DIFF
--- a/srv/fluffi/data/fluffiweb/app/static/javascript/getPopulationGraph.js
+++ b/srv/fluffi/data/fluffiweb/app/static/javascript/getPopulationGraph.js
@@ -39,7 +39,10 @@ function getPopulationGraph(projId) {
             boxSelectionEnabled: false,
             autounselectify: true,
             layout: {
-                name: 'dagre'
+                name: 'dagre',
+                avoidOverlap: true,
+                avoidOverlapPadding: 10,
+                nodeDimensionsIncludeLabels: true
             },
             style: [ {
                 selector: 'node',


### PR DESCRIPTION
Fixed by layout grid options provided by cytoscape js