### PR TITLE
Fix(web): unhandled exceptions

### DIFF
--- a/srv/fluffi/data/fluffiweb/app/templates/base.html
+++ b/srv/fluffi/data/fluffiweb/app/templates/base.html
@@ -34,48 +34,48 @@ Author(s): Junes Najah, Thomas Riedmaier, Abian Blome
 {% macro flashMessages() %}
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
-{% for category, message in messages %}
-{% if category == "error" %}
+    {% for category, message in messages %}
+        {% if category == "error" %}
 
-<div class="alert alert-warning">
-    {{ message }}
-</div>
+            <div class="alert alert-warning">
+                {{ message }}
+            </div>
 
-{% elif category == "success" %}
+        {% elif category == "success" %}
 
-<div class="alert alert-info">
-    <strong>
-        Success!
-    </strong>
-    {{ message }}
-</div>
+            <div class="alert alert-info">
+                <strong>
+                    Success!
+                </strong>
+                {{ message }}
+            </div>
 
-{% elif category == "warning" %}
+        {% elif category == "warning" %}
 
-<div class="alert alert-danger">
-    {{ message }}
-</div>
+            <div class="alert alert-danger">
+                {{ message }}
+            </div>
 
-{% elif category == "addLocation" %}
+        {% elif category == "addLocation" %}
 
-<div class="alert alert-danger">
-    <h4 class="alert-heading">Missing location!</h4>
-    <p>{{ message }}</p>
-    <br>
-    <div class="mb-0 text-right"><a href="/locations/createLocation" type="button" class="btn btn-danger">Add location</a></div>
-</div>
+            <div class="alert alert-danger">
+                <h4 class="alert-heading">Missing location!</h4>
+                <p>{{ message }}</p>
+                <br>
+                <div class="mb-0 text-right"><a href="/locations/createLocation" type="button" class="btn btn-danger">Add location</a></div>
+            </div>
 
-{% elif category == "syncSystems" %}
+        {% elif category == "syncSystems" %}
 
-<div class="alert alert-danger">
-    <h4 class="alert-heading">Sync systems failed!</h4>
-    <p>{{ message }}</p>
-    <br>
-    <div class="mb-0 text-right"><a href="/syncSystems" type="button" class="btn btn-danger">Sync systems</a></div>
-</div>
+            <div class="alert alert-danger">
+                <h4 class="alert-heading">Sync systems failed!</h4>
+                <p>{{ message }}</p>
+                <br>
+                <div class="mb-0 text-right"><a href="/syncSystems" type="button" class="btn btn-danger">Sync systems</a></div>
+            </div>
 
-{% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
 {% endif %}
 {% endwith %}
 {% endmacro %}

--- a/srv/fluffi/data/fluffiweb/app/templates/systems.html
+++ b/srv/fluffi/data/fluffiweb/app/templates/systems.html
@@ -194,6 +194,9 @@ Author(s): Pascal Eckmann, Junes Najah, Michael Kraus, Thomas Riedmaier
 <hr>
 
 <div class="container">
+    {% if not ansibleConnectionWorks %}
+    <div class="alert alert-danger">Ansible connector failed</div>
+    {% endif %}
     {% for group in systems %}
     <h2>Group: <a href="/systems/view/{{ group.Name }}/{{ group.Name }}">{{ group.Name }}</a></h2>
     <div class="container" style="padding-left: 50px">

--- a/srv/fluffi/data/fluffiweb/app/templates/systems.html
+++ b/srv/fluffi/data/fluffiweb/app/templates/systems.html
@@ -165,8 +165,15 @@ Author(s): Pascal Eckmann, Junes Najah, Michael Kraus, Thomas Riedmaier
                     <p>This image is loaded from the FTP server when the PXE-boot is triggered.</p>
                     <form action="{{ url_for('changePXEBootSystemPolemarch', pxebootsystem=pxesystem) }}" method="post">
                         {{changePXEForm.pxesystem.label }}
+
                         {{changePXEForm.pxesystem(class='form-control modal-form')}}
-                        {{changePXEForm.execute_change_pxe(class='btn btn-primary modal-button')}}
+
+                        {% if ftpConnectionWorks %}                            
+                            {{changePXEForm.execute_change_pxe(class='btn btn-primary modal-button')}}
+                        {% else %}
+                            <div class="alert alert-danger">Error: Failed to get files from FTP-Server</div>
+                            {{changePXEForm.execute_change_pxe(class='btn btn-primary modal-button disabled')}}
+                        {% endif %}                        
                     </form>
                     <hr>
                     <p>

--- a/srv/fluffi/data/fluffiweb/app/views.py
+++ b/srv/fluffi/data/fluffiweb/app/views.py
@@ -1061,8 +1061,13 @@ def systems():
     changeAgentStarterModeForm = ChangeAgentStarterModeForm()
     changePXEForm = ChangePXEForm()
     bootsystemdir = models.GmOptions.query.filter_by(setting="bootsystemdir").first().value
-    availablePXEsystems = FTP_CONNECTOR.getListOfFilesOnFTPServer("tftp-roots/")
-    changePXEForm.pxesystem.choices = availablePXEsystems
+
+    try:
+        changePXEForm.pxesystem.choices = FTP_CONNECTOR.getListOfFilesOnFTPServer("tftp-roots/")
+        ftpConnectionWorks = True
+    except:
+        ftpConnectionWorks = False
+        changePXEForm.pxesystem.choices = []
 
     for project in projIds:
         managedInstances, summarySection, localmanagers = getManagedInstancesAndSummary(project.ID)
@@ -1143,10 +1148,10 @@ def systems():
             ANSIBLE_REST_CONNECTOR.execHostAlive()
         except Exception as e:
             print(e)
-        flash(
-            "Error retrieving or parsing data from polemarch! Check polemarch history if polemarch is busy or other "
-            "error occured. Attach to webui docker container....",
-            "error")
+        # flash(
+        #     "Error retrieving or parsing data from polemarch! Check polemarch history if polemarch is busy or other "
+        #     "error occured. Attach to webui docker container....",
+        #     "error")
         locations = []
 
     return renderTemplate("systems.html",
@@ -1154,9 +1159,9 @@ def systems():
                           systems=groups,
                           locations=locations,
                           addNewSystemToPolemarchForm=addNewSystemToPolemarchForm,
+                          ftpConnectionWorks=ftpConnectionWorks,
                           changePXEForm=changePXEForm,
                           bootsystemdir=bootsystemdir,
-                          availablePXEsystems=availablePXEsystems,
                           agentStarterMode=actualAgentStarterMode,
                           changeAgentStarterModeForm=changeAgentStarterModeForm)
 

--- a/srv/fluffi/data/fluffiweb/app/views.py
+++ b/srv/fluffi/data/fluffiweb/app/views.py
@@ -1052,6 +1052,9 @@ def logs():
 @app.route("/systems")
 @checkSystemsLoaded
 def systems():
+    ansibleConnectionWorks = True
+    ftpConnectionWorks = True  
+
     groups = []
     addNewSystemToPolemarchForm = AddNewSystemForm()
     projIds = models.Fuzzjob.query.all()
@@ -1063,9 +1066,9 @@ def systems():
     bootsystemdir = models.GmOptions.query.filter_by(setting="bootsystemdir").first().value
 
     try:
-        changePXEForm.pxesystem.choices = FTP_CONNECTOR.getListOfFilesOnFTPServer("tftp-roots/")
-        ftpConnectionWorks = True
-    except:
+        changePXEForm.pxesystem.choices = FTP_CONNECTOR.getListOfFilesOnFTPServer("tftp-roots/")              
+    except Exception as e:
+        print("Error", e)
         ftpConnectionWorks = False
         changePXEForm.pxesystem.choices = []
 
@@ -1141,18 +1144,15 @@ def systems():
                 if not hasattr(h, 'confLM'):
                     h.confLM = 0
 
-        locations = models.Locations.query.all()
+        locations = models.Locations.query.all()        
     except Exception as e:
         print(e)
+        ansibleConnectionWorks = False
+        locations = []
         try:
             ANSIBLE_REST_CONNECTOR.execHostAlive()
         except Exception as e:
-            print(e)
-        # flash(
-        #     "Error retrieving or parsing data from polemarch! Check polemarch history if polemarch is busy or other "
-        #     "error occured. Attach to webui docker container....",
-        #     "error")
-        locations = []
+            print(e)        
 
     return renderTemplate("systems.html",
                           title="Systems",
@@ -1160,6 +1160,7 @@ def systems():
                           locations=locations,
                           addNewSystemToPolemarchForm=addNewSystemToPolemarchForm,
                           ftpConnectionWorks=ftpConnectionWorks,
+                          ansibleConnectionWorks=ansibleConnectionWorks,
                           changePXEForm=changePXEForm,
                           bootsystemdir=bootsystemdir,
                           agentStarterMode=actualAgentStarterMode,


### PR DESCRIPTION
- handle unavailable ftp server by displaying error message in modal and disabling change button
- display error message in case AnsibleRestConnector fails (flash() did not work without a redirect)