### PR TITLE
Windows initialization fixes and improvements

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -200,7 +200,7 @@ The following directories and their subdirectories contain a number of placehold
 - `/srv/fluffi/data/smb/files/initial/updatesWS2008`
 - `/srv/fluffi/data/ftp/files/initial/windows/ansible`
 
-All the files in there are dummy files named like the real files that have to go in there, but they are actually just textfiles that contain a download link.
+Most of the files in there are dummy files named like the real files that have to go in there, but they are actually just textfiles that contain a download link.
 Download the binaries from these links and replace the placeholder textfiles with their respective binaries.
 
 Get the GlobalManager components from where you [compiled FLUFFI core](#compiling-fluffi-core) - specifically, you need to copy

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/PrivateNetwork/network.ps1
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/PrivateNetwork/network.ps1
@@ -1,3 +1,27 @@
+<#
+Copyright 2017-2020 Siemens AG
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Author(s): Pascal Eckmann
+#>
+
 $networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")) 
 $connections = $networkListManager.GetNetworkConnections() 
 

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/PrivateNetwork/network.ps1
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/PrivateNetwork/network.ps1
@@ -1,0 +1,5 @@
+$networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")) 
+$connections = $networkListManager.GetNetworkConnections() 
+
+# Set network location to Private for all networks 
+$connections | % {$_.GetNetwork().SetCategory(1)}

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/PsExec/PsExecx64.exe
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/PsExec/PsExecx64.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afec66431c756c7619bd2d5635bd4cc9ba4cfdd570ab40e91689df211602c728
+size 111

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/PsExec/PsExecx86.exe
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/PsExec/PsExecx86.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8df1e1864e85a190bc03f2e7caf506666bdc2ef0e8a0630c7684ef02b0fa6db1
+size 109

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/Python/pythonx64.exe
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/Python/pythonx64.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:701eb0302735a418aaf3591a5eb0dcd53a2b77ef930b3a1fb5eb3790a89ccd2a
+size 117

--- a/srv/fluffi/data/ftp/files/initial/windows/ansible/Python/pythonx86.exe
+++ b/srv/fluffi/data/ftp/files/initial/windows/ansible/Python/pythonx86.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a89d6bd0756dfa7aa64e7956e4394c790726024eb4e8c515784da4430bbf8cb7
+size 105

--- a/srv/fluffi/data/polenext/projects/1/initialSetup.yml
+++ b/srv/fluffi/data/polenext/projects/1/initialSetup.yml
@@ -40,7 +40,10 @@
 - hosts: windows
   roles:
     - initial-windows-Timezone
+    - initial-windows-PrivateNetwork
     - initial-windows-GFlags
+    - initial-windows-Python
+    - initial-windows-PsExec
     - initial-windows-PrepareEnvironment
     - initial-windows-GroupPolicy
     - initial-windows-pagefile

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GFlags/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GFlags/tasks/main.yml
@@ -35,11 +35,21 @@
     url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{GFlagsDirname}}/{{GFlagsZipFilename}}"
     dest: "{{remoteUtilitiesFilePath}}{{GFlagsDirname}}\\{{GFlagsZipFilename}}"
 
+- name: Check file size
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{GFlagsDirname}}\\{{GFlagsZipFilename}}"
+  register: file_size
+
 - name: Unzip GFlags
   win_unzip:
     src: "{{remoteUtilitiesFilePath}}\\{{GFlagsDirname}}\\{{GFlagsZipFilename}}"
     dest: "{{remoteUtilitiesFilePath}}{{GFlagsDirname}}"
     delete_archive: yes
+  when: file_size.stat.size > 200
+
+- fail:
+    msg: GFlags archive is smaller than 200 Bytes
+  when: file_size.stat.size <= 200
 
 #- name: Globally enable Page Heap
 #  win_command: gflags.exe -r +hpa

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GFlags/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GFlags/tasks/main.yml
@@ -48,7 +48,7 @@
   when: file_size.stat.size > 200
 
 - fail:
-    msg: GFlags archive is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size.stat.size <= 200
 
 #- name: Globally enable Page Heap

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GroupPolicy/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GroupPolicy/tasks/main.yml
@@ -29,16 +29,23 @@
 #  win_copy:
 #    src: "{{LGPOExecutableFileName}}"
 #    dest: "{{remoteUtilitiesFilePath}}"
+
+- name: Check file size
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{LGPOExecutableFileName}}"
+  register: file_size
     
 - name: Copy {{groupPolicyFileNameTxt}} to remote machine via template
   win_template:
     src: "{{groupPolicyFileNameTxt}}"
     dest: "{{remoteUtilitiesFilePath}}\\{{groupPolicyFileNameTxt}}"
+  when: file_size.stat.size > 200
 
 - name: Execute {{LGPOExecutableFileName}} to generate group policy {{groupPolicyFileNamePol}}
   win_command: "{{LGPOExecutableFileName}} /r {{groupPolicyFileNameTxt}} /w {{groupPolicyFileNamePol}}"
   args:
-    chdir: "{{remoteUtilitiesFilePath}}"    
+    chdir: "{{remoteUtilitiesFilePath}}"
+  when: file_size.stat.size > 200
 
 - name: Execute {{LGPOExecutableFileName}} to apply group policy {{groupPolicyFileNamePol}}
   win_command: "{{LGPOExecutableFileName}} /m .\\{{groupPolicyFileNamePol}}"
@@ -47,3 +54,9 @@
   notify:
     - Ensure Windows NTP service is running
     - Force Windows NTP time sync
+  when: file_size.stat.size > 200
+
+- fail:
+    msg: LGPO file is smaller than 200 Bytes
+  when: file_size.stat.size <= 200
+

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GroupPolicy/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-GroupPolicy/tasks/main.yml
@@ -57,6 +57,6 @@
   when: file_size.stat.size > 200
 
 - fail:
-    msg: LGPO file is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size.stat.size <= 200
 

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Imdisk/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Imdisk/tasks/main.yml
@@ -79,5 +79,5 @@
   when: file_size.stat.size > 200
 
 - fail:
-    msg: lmDisk file is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size.stat.size <= 200

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Imdisk/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Imdisk/tasks/main.yml
@@ -30,27 +30,36 @@
     url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{ImdiskFTPDirname}}/{{ImdiskInstallerFileName}}"
     dest: "{{remoteUtilitiesFilePath}}{{ImdiskInstallerFileName}}"
 
+- name: Check file size
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{ImdiskInstallerFileName}}"
+  register: file_size
+
 - name: Install imdisk by executing {{ImdiskInstallerFileName}}
   win_package:
     path: "{{remoteUtilitiesFilePath}}{{ImdiskInstallerFileName}}"
     product_id: imdisk
     arguments: /fullsilent
+  when: file_size.stat.size > 200
 
 - name: Create new ramdisk
   win_command: "imdisk -a -s {{RamDiskSize}} -m {{ramDiskMountpointLetter}}: -p \"/fs:ntfs /q /y\""
   args:
     creates: "{{ramDiskMountpointLetter}}:\\"
+  when: file_size.stat.size > 200
 
 - name: Ensure startup script directory exists
   win_file:
     path: "{{startupscriptDirectory}}"
     state: directory
+  when: file_size.stat.size > 200
 
 - name: Copy startup script to machine
   win_template:
     src: "{{startupscriptFilename}}"
     dest: "{{startupscriptDirectory}}\\{{startupscriptFilename}}"
   ignore_errors: True
+  when: file_size.stat.size > 200
 
 - name: Add task schedule to run script at start up
   win_scheduled_task:
@@ -67,3 +76,8 @@
     run_level: highest
     state: present
     enabled: yes
+  when: file_size.stat.size > 200
+
+- fail:
+    msg: lmDisk file is smaller than 200 Bytes
+  when: file_size.stat.size <= 200

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PrivateNetwork/defaults/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PrivateNetwork/defaults/main.yml
@@ -18,23 +18,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # 
-# Author(s): Pascal Eckmann, Junes Najah, Thomas Riedmaier
- 
-- name: Fetch autologon from "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-  win_get_url: 
-    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-    dest: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
+# Author(s): Pascal Eckmann
 
-- name: Check file size
-  win_stat:
-    path: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
-  register: file_size
-
-- name: Run autologon
-  win_command: "{{remoteUtilitiesFilePath}}{{autologonFile}} -accepteula {{ ansible_user }} {{ inventory_hostname }} {{ ansible_password }}"
-  when: file_size.stat.size > 200
-
-- fail:
-    msg: autologon file is smaller than 200 Bytes
-  when: file_size.stat.size <= 200
-  
+NetworkDirname : "PrivateNetwork"
+NetworkScriptFilename: "network.ps1"

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PrivateNetwork/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PrivateNetwork/tasks/main.yml
@@ -18,23 +18,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # 
-# Author(s): Pascal Eckmann, Junes Najah, Thomas Riedmaier
- 
-- name: Fetch autologon from "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
+# Author(s): Pascal Eckmann
+
+- name: Ensure source directory exists
+  win_file:
+    path: "{{remoteUtilitiesFilePath}}{{NetworkDirname}}"
+    state: directory
+
+- name: Fetch network private script "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{NetworkDirname}}/{{NetworkScriptFilename}}"
   win_get_url: 
-    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-    dest: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
+    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{NetworkDirname}}/{{NetworkScriptFilename}}"
+    dest: "{{remoteUtilitiesFilePath}}{{NetworkDirname}}\\{{NetworkScriptFilename}}"
 
-- name: Check file size
-  win_stat:
-    path: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
-  register: file_size
+- name: Execute network private script
+  win_shell: "{{remoteUtilitiesFilePath}}{{NetworkDirname}}\\{{NetworkScriptFilename}}"
 
-- name: Run autologon
-  win_command: "{{remoteUtilitiesFilePath}}{{autologonFile}} -accepteula {{ ansible_user }} {{ inventory_hostname }} {{ ansible_password }}"
-  when: file_size.stat.size > 200
 
-- fail:
-    msg: autologon file is smaller than 200 Bytes
-  when: file_size.stat.size <= 200
-  
+

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/defaults/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/defaults/main.yml
@@ -18,23 +18,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # 
-# Author(s): Pascal Eckmann, Junes Najah, Thomas Riedmaier
- 
-- name: Fetch autologon from "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-  win_get_url: 
-    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-    dest: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
+# Author(s): Pascal Eckmann
 
-- name: Check file size
-  win_stat:
-    path: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
-  register: file_size
-
-- name: Run autologon
-  win_command: "{{remoteUtilitiesFilePath}}{{autologonFile}} -accepteula {{ ansible_user }} {{ inventory_hostname }} {{ ansible_password }}"
-  when: file_size.stat.size > 200
-
-- fail:
-    msg: autologon file is smaller than 200 Bytes
-  when: file_size.stat.size <= 200
-  
+PsExecDirname : "PsExec"
+PsExecX86Filename: "PsExecx86.exe"
+PsExecX64Filename: "PsExecx64.exe"

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/tasks/main.yml
@@ -18,23 +18,34 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # 
-# Author(s): Pascal Eckmann, Junes Najah, Thomas Riedmaier
- 
-- name: Fetch autologon from "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
+# Author(s): Pascal Eckmann
+
+- name: Ensure source directory exists
+  win_file:
+    path: "{{remoteUtilitiesFilePath}}{{PsExecDirname}}"
+    state: directory
+
+- name: Fetch PsExec file "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PsExecDirname}}/{{PsExecX86Filename}}"
   win_get_url: 
-    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-    dest: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
+    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PsExecDirname}}/{{PsExecX86Filename}}"
+    dest: "{{remoteUtilitiesFilePath}}{{PsExecDirname}}\\{{PsExecX86Filename}}"
+
+- name: Check file size 
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{PsExecDirname}}\\{{PsExecX86Filename}}"
+  register: file_size_1
+
+- name: Fetch PsExec file "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PsExecDirname}}/{{PsExecX64Filename}}"
+  win_get_url: 
+    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PsExecDirname}}/{{PsExecX64Filename}}"
+    dest: "{{remoteUtilitiesFilePath}}{{PsExecDirname}}\\{{PsExecX64Filename}}"
 
 - name: Check file size
   win_stat:
-    path: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
-  register: file_size
-
-- name: Run autologon
-  win_command: "{{remoteUtilitiesFilePath}}{{autologonFile}} -accepteula {{ ansible_user }} {{ inventory_hostname }} {{ ansible_password }}"
-  when: file_size.stat.size > 200
+    path: "{{remoteUtilitiesFilePath}}{{PsExecDirname}}\\{{PsExecX64Filename}}"
+  register: file_size_2
 
 - fail:
-    msg: autologon file is smaller than 200 Bytes
-  when: file_size.stat.size <= 200
-  
+    msg: PsExec is smaller than 200 Bytes
+  when: file_size_1.stat.size <= 200 or file_size_2.stat.size <= 200
+

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-PsExec/tasks/main.yml
@@ -46,6 +46,6 @@
   register: file_size_2
 
 - fail:
-    msg: PsExec is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size_1.stat.size <= 200 or file_size_2.stat.size <= 200
 

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/defaults/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/defaults/main.yml
@@ -18,23 +18,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # 
-# Author(s): Pascal Eckmann, Junes Najah, Thomas Riedmaier
- 
-- name: Fetch autologon from "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-  win_get_url: 
-    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{autologonFolderName}}/{{autologonFile}}"
-    dest: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
+# Author(s): Pascal Eckmann
 
-- name: Check file size
-  win_stat:
-    path: "{{remoteUtilitiesFilePath}}{{autologonFile}}"
-  register: file_size
-
-- name: Run autologon
-  win_command: "{{remoteUtilitiesFilePath}}{{autologonFile}} -accepteula {{ ansible_user }} {{ inventory_hostname }} {{ ansible_password }}"
-  when: file_size.stat.size > 200
-
-- fail:
-    msg: autologon file is smaller than 200 Bytes
-  when: file_size.stat.size <= 200
-  
+PythonDirname : "Python"
+PythonX86Filename: "pythonx86.exe"
+PythonX64Filename: "pythonx64.exe"
+installerFlags: /s

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/tasks/main.yml
@@ -1,0 +1,71 @@
+# Copyright 2017-2020 Siemens AG
+# 
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including without
+# limitation the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# 
+# Author(s): Pascal Eckmann
+
+- name: Ensure source directory exists
+  win_file:
+    path: "{{remoteUtilitiesFilePath}}{{PythonDirname}}"
+    state: directory
+
+- name: Fetch Python X86 file "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PythonDirname}}/{{PythonX86Filename}}"
+  win_get_url: 
+    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PythonDirname}}/{{PythonX86Filename}}"
+    dest: "{{remoteUtilitiesFilePath}}{{PythonDirname}}\\{{PythonX86Filename}}"
+
+- name: Check file size 
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{PythonDirname}}\\{{PythonX86Filename}}"
+  register: file_size_1
+
+- name: Fetch Python X64 file "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PythonDirname}}/{{PythonX64Filename}}"
+  win_get_url: 
+    url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{PythonDirname}}/{{PythonX64Filename}}"
+    dest: "{{remoteUtilitiesFilePath}}{{PythonDirname}}\\{{PythonX64Filename}}"
+
+- name: Check file size
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{PythonDirname}}\\{{PythonX64Filename}}"
+  register: file_size_2
+
+- fail:
+    msg: Python file is smaller than 200 Bytes
+  when: file_size_1.stat.size <= 200 or file_size_2.stat.size <= 200
+
+- name: Execute install script of Python on the remote machine
+  win_package:
+    path: "{{remoteUtilitiesFilePath}}{{PythonDirname}}\\python{{architecture}}.exe"
+    product_id: Microsoft Windows
+    arguments: "{{ installerFlags }}"
+  ignore_errors: True
+  when: file_size_1.stat.size > 200 or file_size_2.stat.size > 200
+
+- name: Create PYTHON_HOME Environment Variable for all users
+  win_environment:
+    state: present
+    name: PYTHON_HOME
+    value: "C:\\Users\\{{ansible_user}}\\AppData\\Local\\Programs\\Python\\Python38"
+    level: machine
+
+- name: Set python path
+  win_path:
+    elements: '%PYTHON_HOME%'
+  when: file_size_1.stat.size > 200 or file_size_2.stat.size > 200
+

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-Python/tasks/main.yml
@@ -46,7 +46,7 @@
   register: file_size_2
 
 - fail:
-    msg: Python file is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size_1.stat.size <= 200 or file_size_2.stat.size <= 200
 
 - name: Execute install script of Python on the remote machine

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-VCRedistributables/tasks/fetchAndInstallRedistributable.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-VCRedistributables/tasks/fetchAndInstallRedistributable.yml
@@ -25,14 +25,25 @@
     url: "{{ftpserverURL}}/{{initialAnsibleFTPPath}}/{{FTPRedistributableDirname}}/{{pkgName}}/{{installerFilename}}"
     dest: "{{remoteUtilitiesFilePath}}{{installerFilename}}"
 
+- name: Check file size
+  win_stat:
+    path: "{{remoteUtilitiesFilePath}}{{installerFilename}}"
+  register: file_size
+
 - name: Install redistributable "{{remoteUtilitiesFilePath}}{{installerFilename}}"
   win_package:
     path: "{{remoteUtilitiesFilePath}}{{installerFilename}}"
     product_id: Microsoft Windows
     arguments: "{{ installerFlags }}"
   ignore_errors: True
+  when: file_size.stat.size > 200
 
 - name: Delete "{{remoteUtilitiesFilePath}}{{installerFilename}}"
   win_file:
     path: "{{remoteUtilitiesFilePath}}{{installerFilename}}"
     state: absent
+  when: file_size.stat.size > 200
+
+- fail:
+    msg: redistributable installer is smaller than 200 Bytes
+  when: file_size.stat.size <= 200

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-VCRedistributables/tasks/fetchAndInstallRedistributable.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-VCRedistributables/tasks/fetchAndInstallRedistributable.yml
@@ -45,5 +45,5 @@
   when: file_size.stat.size > 200
 
 - fail:
-    msg: redistributable installer is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size.stat.size <= 200

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-autologon/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-autologon/tasks/main.yml
@@ -35,6 +35,6 @@
   when: file_size.stat.size > 200
 
 - fail:
-    msg: autologon file is smaller than 200 Bytes
+    msg: "File too small. Did you replace the stub files with the actual files?" 
   when: file_size.stat.size <= 200
   

--- a/srv/fluffi/data/polenext/projects/1/roles/initial-windows-deployRestInstanceStarter/tasks/main.yml
+++ b/srv/fluffi/data/polenext/projects/1/roles/initial-windows-deployRestInstanceStarter/tasks/main.yml
@@ -37,4 +37,4 @@
 - name: Fetch Rest-Instance-Starter-Autostart from "{{ftpserverURL}}/restStarter/restInstanceAutostart.bat"
   win_get_url: 
     url: "{{ftpserverURL}}/restStarter/restInstanceAutostart.bat"
-    dest: "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\restInstanceAutostart.bat"
+    dest: "C:\\Users\\{{ansible_user}}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\restInstanceAutostart.bat"


### PR DESCRIPTION
fix restInstanceStarter (added Python to ansible folder)
remove hardcoded path in deployRestInstanceStarter
Windows networks will now be set to private
stub binaries error handling

fix #151 
fix #154 
fix #167 
fix #168 

*.exe files in this PR are text files with download link to their real counterpart and one liner how to rename them.
