### PR TITLE
fix(build): fix out of memory error during dependency build

### DIFF
--- a/core/dependencies/openssl/make_dep.sh
+++ b/core/dependencies/openssl/make_dep.sh
@@ -8,7 +8,7 @@
 #
 # Author(s): Thomas Riedmaier, Roman Bendt
 
-HREADS=$(nproc)
+THREADS=$(nproc)
 ARCH=$(file /bin/bash | awk -F',' '{print $2}' | tr -d ' ')
 
 rm -rf include


### PR DESCRIPTION
lol. smallest commit ever.

closes #234

