### PR TITLE
Rollback DynamoRIO

### DIFF
--- a/core/dependencies/dynamorio/make_dep.bat
+++ b/core/dependencies/dynamorio/make_dep.bat
@@ -48,7 +48,7 @@ REM Getting dynamorio from git
 
 git clone https://github.com/DynamoRIO/dynamorio.git
 cd dynamorio
-git checkout 1ddc1a79579c6efce1baa264de600654d00f6bda
+git checkout b9d0d9efebcc05cbc63811337cb687ccfeda149c
 
 REM Copy files for the drcovMulti module
 MKDIR clients\drcovMulti

--- a/core/dependencies/dynamorio/make_dep.sh
+++ b/core/dependencies/dynamorio/make_dep.sh
@@ -46,7 +46,7 @@ rm -rf dynamorio
 
 git clone https://github.com/DynamoRIO/dynamorio.git
 cd dynamorio
-git checkout 1ddc1a79579c6efce1baa264de600654d00f6bda
+git checkout b9d0d9efebcc05cbc63811337cb687ccfeda149c
 
 # Copy files for the drcovMulti module
 mkdir -p clients/drcovMulti


### PR DESCRIPTION
Fixes #271

I believe the issue is that `TestExecutorDynRio.h` has `#include <core/lib/globals_shared.h>`. `globals_shared.h` is a header file that is supposed to just be used internally by DynamoRIO, so a different file should be included.

The other issue is that updating DynamoRIO may break the `.patch` files in `core/dependencies/dynamorio` (including the `.patch` files in upcoming PRs for edge coverage, since they are based on the older version).